### PR TITLE
Expose original spark stream as _spark.

### DIFF
--- a/lib/spark_stream.js
+++ b/lib/spark_stream.js
@@ -4,6 +4,9 @@ var Duplex = require('stream').Duplex;
 module.exports = function sparkStream(spark) {
   var stream = new Duplex({objectMode: true});
 
+  // Expose underlying spark for later access in sharejs request objects.
+  stream._spark = spark;
+
   stream._write = function (chunk, encoding, callback) {
     spark.write(chunk);
     callback();


### PR DESCRIPTION
I use this to identify requests in sharejs middleware like this, as I haven't found another way to match request objects in sharejs to their underlying connection.

``` js
function submitMiddleware(request, next) {
  var id = request.agent.session.stream._spark.id;
  if (!auth(id)) {
    return next('Not authenticated');
  } 
  next();
}
```
