### PR TITLE
Cleanup spark_stream and add tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Primus](https://github.com/primus/primus) bindings for [ShareJS](https://github.com/share/ShareJS).
 
-Share-Primus is a client (browser side) extension to ShareJS that lets you use ShareJS with WebSockets, 
+Share-Primus is a client (browser side) extension to ShareJS that lets you use ShareJS with WebSockets,
 BrowserChannel, SockJS or any other streaming library supported by Primus.
 
 Primus also has several useful plugins such as [Substream](https://github.com/primus/substream), which
@@ -41,7 +41,7 @@ var primus = new Primus(server);
 var shareClient = share.server.createClient({backend:backend});
 
 primus.on('connection', function (spark) {
-  shareClient.listen(sharePrimus.sparkStream(spark));
+  shareClient.listen(new sharePrimus.SparkStream(spark));
 });
 ```
 
@@ -62,8 +62,7 @@ node example/server.js --transformer=[websockets|browserchannel|sockjs|engine.io
 IMPORTANT! When you start the server the first time, Primus will tell you to `npm install`
 the underlying streaming framework first. Pay close attention to the error message.
 
-The example code is a little more sophisticated than the code above. 
+The example code is a little more sophisticated than the code above.
 It also sets up a substream for sending non-sharejs messages over the same connection.
 
 Open a browser: http://localhost:7008/
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
 var path = require('path');
 
-module.exports.scriptsDir = path.join(__dirname, 'client');
-module.exports.sparkStream = require('./spark_stream');
+exports.scriptsDir = path.join(__dirname, 'client');
+exports.SparkStream = require('./spark_stream');

--- a/lib/spark_stream.js
+++ b/lib/spark_stream.js
@@ -1,33 +1,48 @@
 var Duplex = require('stream').Duplex;
+var inherits = require('util').inherits;
 
 // Workaround for https://github.com/primus/primus/issues/121
-module.exports = function sparkStream(spark) {
-  var stream = new Duplex({objectMode: true});
 
-  // Expose underlying spark for later access in sharejs request objects.
-  stream._spark = spark;
 
-  stream._write = function (chunk, encoding, callback) {
-    spark.write(chunk);
-    callback();
-  };
+function SparkStream(spark) {
+  if (!(this instanceof SparkStream)) return new SparkStream(spark);
 
-  stream._read = function() {};
-
-  stream.on('error', function () {
-    client.stop();
+  Duplex.call(this, {
+    objectMode: true,
+    allowHalfOpen: false
   });
 
-  spark.on('data', function (data) {
-    stream.push(data);
-  });
+  // Store a reference to the underlying spark stream
+  this._spark = spark;
 
-  spark.on('close', function () {
-    stream.emit('close');
-    stream.emit('end');
-    stream.end();
-  });
+  // Listen to data events from the spark and push them
+  // into the stream.
+  spark.on('data', this.push.bind(this));
 
-  return stream;
+  // Listen to the close event of the spark stream.
+  //spark.on('close', this.push.bind(this, null));
+  spark.on('end', function () {
+    this.resume();
+    this.push(null);
+  }.bind(this));
+
+  // Emit error events
+  spark.on('error', this.emit.bind(this, 'error'));
+}
+
+inherits(SparkStream, Duplex);
+
+// Implement the `_write` method for the writable part of the
+// Duplex stream.
+SparkStream.prototype._write = function (chunk, encoding, cb) {
+  this._spark.write(chunk);
+  cb();
 };
 
+// Implement the `_read` method for th readable part of the
+// Duplex stream.
+SparkStream.prototype._read = function () {
+};
+
+
+module.exports = SparkStream;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Primus bindings for ShareJS",
   "main": "lib/index.js",
   "scripts": {
-    "build-sharejs": "cd node_modules/share && make webclient UGLIFY=\"../../node_modules/.bin/uglifyjs -d WEB=true\""
+    "build-sharejs": "cd node_modules/share && make webclient UGLIFY=\"../../node_modules/.bin/uglifyjs -d WEB=true\"",
+    "test": "node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,11 @@
     "livedb-mongo": "~0.3.0",
     "optimist": "~0.6.1",
     "substream": "git://github.com/primus/substream.git#31ceda3954f79546de66c2e26c80f30a5c33ee48",
-    "ws": "~0.4.31"
+    "ws": "^0.4.31",
+    "chai": "^1.9.1",
+    "mocha": "^1.18.2",
+    "sinon": "^1.9.0",
+    "primus": "^2.0.2",
+    "sinon-chai": "^2.5.0"
   }
 }

--- a/test/spark_stream.spec.js
+++ b/test/spark_stream.spec.js
@@ -1,0 +1,65 @@
+var chai = require('chai')
+chai.use(require('sinon-chai'));
+var expect = chai.expect;
+var EventEmitter = require('events').EventEmitter;
+var sinon = require('sinon');
+var Primus = require('primus');
+var Spark = Primus.Spark;
+var http = require('http');
+
+var SparkStream = require('../lib/spark_stream');
+
+
+describe('SparkStream', function () {
+  it('is instantiable', function () {
+    var spark = new Spark(new Primus(http.createServer()));
+    expect(new SparkStream(spark)).to.be.an.instanceOf(SparkStream);
+  });
+
+  it('writes to the underlying spark', function () {
+    var spark = new EventEmitter();
+    spark.write = sinon.stub();
+    var stream = new SparkStream(spark);
+    stream.write('hello world');
+    expect(spark.write).to.have.been.calledWith('hello world');
+  });
+
+  it('emits data from the underlying spark', function (done) {
+    var spark = new EventEmitter();
+    var stream = new SparkStream(spark);
+    stream.on('data', function (data) {
+      expect(data).to.be.eql('hello world');
+      done();
+    });
+    spark.emit('data', 'hello world');
+  });
+
+  it('emits an end event when the spark stream closes', function (done) {
+    var spark = new EventEmitter();
+    var stream = new SparkStream(spark);
+
+    stream.on('end', function () {
+      done();
+    });
+    spark.emit('end');
+  });
+  it('emits a finish event when the spark stream closes', function (done) {
+    var spark = new EventEmitter();
+    var stream = new SparkStream(spark);
+
+    stream.on('finish', function () {
+      done();
+    });
+    spark.emit('end');
+  });
+  it('emits an error when the spark stream has an error', function (done) {
+    var spark = new EventEmitter();
+    var stream = new SparkStream(spark);
+
+    stream.on('error', function (err) {
+      expect(err).to.be.eql('error');
+      done();
+    });
+    spark.emit('error', 'error');
+  });
+});


### PR DESCRIPTION
This addresses the following things:
- Refactor `sparkStream` to a proper extension of `stream.Duplex` and make it a constructor.
- Add basic tests for `SparkStream`
- Listen to the `end` event instead of `close` on the spark. (`close` doesn't exist)
- emit errors from the spark on the `SparkStream`.
